### PR TITLE
Specify `"type": "module"` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
 	"name": "prism-svelte",
 	"version": "0.4.7",
 	"description": "Svelte language extension for prismjs",
-	"main": "index.js",
+	"type": "module",
+  "main": "index.js",
 	"author": "pngwn <hello@pngwn.io>",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Vite can't figure out if this package is CJS or ESM since it has no imports or exports and logs a warning about it that this change will silence. It works either way, but is probably nicer to make it an ES package since that's the way the world is moving