### PR TITLE
Fix block syntax highlighting

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ Prism.languages.svelte = Prism.languages.extend('markup', {
 	},
 	block: {
 		pattern: new RegExp(
-			'{[#:/@]/s' +
+			'{[#:/@]' +
 				blocks +
 				'(?:(?:\\{(?:(?:\\{(?:[^{}])*\\})|(?:[^{}]))*\\})|(?:[^{}]))*}'
 		),


### PR DESCRIPTION
Some token keywords like `@debug` and `@html` don't seem to be highlighted.

Removing the `/s` in the block pattern regular expression seems to fix this.

REPL: https://svelte.dev/repl/6c1b4842c8af48f4b0f3c9512f4408ea?version=3.48.0

---

### Before

<img width="855" alt="Screen Shot 2022-06-25 at 12 16 00 PM" src="https://user-images.githubusercontent.com/10718366/175787686-2df62533-8952-4b7f-b66b-402a00fb387f.png">

### After

<img width="855" alt="Screen Shot 2022-06-25 at 12 16 08 PM" src="https://user-images.githubusercontent.com/10718366/175787690-5efd2028-2b8b-4695-94f4-6c88bc7242f4.png">
