### PR TITLE
feat: Use module and exports fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,13 @@
 	"version": "0.5.0",
 	"description": "Svelte language extension for prismjs",
 	"type": "module",
-	"main": "index.js",
+	"module": "index.js",
+	"exports": {
+		".": {
+			"import": "./index.js"
+		},
+		"./package.json": "./package.json"
+	},
 	"author": "pngwn <hello@pngwn.io>",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Hi there, I've just tried adding this package to TanStack/tanstack.com and got the following ESM error:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../tanstack.com/node_modules/prism-svelte/index.js from .../tanstack.com/api/index.js not supported.
.../tanstack.com/node_modules/prism-svelte/index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename .../tanstack.com/node_modules/prism-svelte/index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in .../tanstack.com/node_modules/prism-svelte/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```

Publint finds a similar error: https://publint.dev/prism-svelte@0.5.0

This PR replaces the main field with a module field, and adds an exports map.